### PR TITLE
Update GitHub “Open in Desktop” URL

### DIFF
--- a/src-chrome/main.js
+++ b/src-chrome/main.js
@@ -1,7 +1,7 @@
 (function() {
-    var buttonElement = document.querySelector("a[data-url^='github-mac://']");
+    var buttonElement = document.querySelector("a[href^='x-github-client://']");
 
     if ( buttonElement != null ) {
-        buttonElement.href = buttonElement.getAttribute("data-url");
+        buttonElement.href = "gittower://openRepo/" + buttonElement.getAttribute("href").substring(27);
     }
 }());

--- a/src-safari/GithubTower.safariextension/main.js
+++ b/src-safari/GithubTower.safariextension/main.js
@@ -1,7 +1,7 @@
 (function() {
-    var buttonElement = document.querySelector("a[data-url^='github-mac://']");
+    var buttonElement = document.querySelector("a[href^='x-github-client://']");
 
     if ( buttonElement != null ) {
-        buttonElement.href = buttonElement.getAttribute("data-url");
+        buttonElement.href = "gittower://openRepo/" + buttonElement.getAttribute("href").substring(27);
     }
 }());


### PR DESCRIPTION
Update to work with GitHub's “Open in Desktop” buttons, which currently use a plain `href` attribute instead of a data-attribute.