### PR TITLE
make work with new 'x-github-client' protocol (and Tower v1 and v2)

### DIFF
--- a/src-chrome/main.js
+++ b/src-chrome/main.js
@@ -1,7 +1,7 @@
 (function() {
-    var buttonElement = document.querySelector("a[data-url^='github-mac://']");
+    var buttonElement = document.querySelector("a[href^='x-github-client://']");
 
     if ( buttonElement != null ) {
-        buttonElement.href = buttonElement.getAttribute("data-url");
+       buttonElement.href = "github-mac://openRepo/" + buttonElement.getAttribute("href").substring(27);
     }
 }());

--- a/src-safari/GithubTower.safariextension/main.js
+++ b/src-safari/GithubTower.safariextension/main.js
@@ -1,7 +1,7 @@
 (function() {
-    var buttonElement = document.querySelector("a[data-url^='github-mac://']");
+    var buttonElement = document.querySelector("a[href^='x-github-client://']");
 
     if ( buttonElement != null ) {
-        buttonElement.href = buttonElement.getAttribute("data-url");
+        buttonElement.href = "github-mac://openRepo/" + buttonElement.getAttribute("href").substring(27);
     }
 }());


### PR DESCRIPTION
The new "Electron" version of Github Desktop seems to require a different URL scheme in order to "Clone in Desktop", whereas it no longer uses the 'github-mac' scheme and instead uses 'x-github-client' scheme. In addition the link on github.com no longer is attached to the data-url attribute but instead is attached via href attribute.